### PR TITLE
Use course image instead of the default

### DIFF
--- a/course.yml
+++ b/course.yml
@@ -11,6 +11,8 @@ university: DataCamp
 difficulty_level: 1
 time_needed: 4 horas
 programming_language: python
+from: "python-base-prod:20"
 datasets:
   baseball.csv: Baseball
   fifa.csv: Fifa
+

--- a/requirements.sh
+++ b/requirements.sh
@@ -1,0 +1,3 @@
+pip3 install numpy==1.11.0
+pip3 install scipy==0.18.1
+


### PR DESCRIPTION
Now that the course is hosted on the community, it's best that it gets it own Docker image that is spinned up for students taking it. This makes the course faster and more stable.